### PR TITLE
Launch4j mac code also works in Linux

### DIFF
--- a/src/com/robotality/jarwrapper/JarWrapper.java
+++ b/src/com/robotality/jarwrapper/JarWrapper.java
@@ -170,7 +170,7 @@ public class JarWrapper {
 		writeToFile(launch4jString, launch4jconfig);
 		
 		// Each OS will need it's own execution of launch4j
-		if(isMacOSX){
+		if(isMacOSX || isLinux){
 			String configPath = "./"  + outputPath + "/jarwrapper.launch4j.xml";
 			Runtime.getRuntime().exec("win/launch4j/launch4j " + configPath);
 			


### PR DESCRIPTION
I'm going to use your utility to wrap our application with the JDK (great tool, btw!). I use Linux (Ubuntu), and well, the code to use launch4j for Mac just works for Linux.
